### PR TITLE
リントの設定を修正（Dto用にPropertyDefinitionを含むように設定）

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -34,7 +34,7 @@ module.exports = {
     indent: [
       'error',
       2,
-      { SwitchCase: 1, ignoredNodes: ['PropertyDefinition'] },
+      { ignoredNodes: ['PropertyDefinition'] },
     ],
     'no-tabs': 'error',
   },

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -31,7 +31,11 @@ module.exports = {
         trailingComma: 'all',
       },
     ],
-    indent: ['error', 2],
+    indent: [
+      'error',
+      2,
+      { SwitchCase: 1, ignoredNodes: ['PropertyDefinition'] },
+    ],
     'no-tabs': 'error',
   },
 };

--- a/src/main.ts
+++ b/src/main.ts
@@ -10,6 +10,7 @@ async function bootstrap() {
   app.useGlobalPipes(
     new ValidationPipe({
       transform: true,
+
       exceptionFactory: (errors) => {
         const messages = errors.map((error) => ({
           field: error.property,


### PR DESCRIPTION
ignoredNodesオプションがPropertyDefinitionを含むように設定
それによって、クラス内でのプロパティ定義に対するインデントルールが無視されるようになった